### PR TITLE
New connectors: radioeins and fritz

### DIFF
--- a/connectors/fritz.js
+++ b/connectors/fritz.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/* global Connector */
+
+Connector.playerSelector = 'div.layoutnowonair_reload_active';
+Connector.artistSelector = 'div.teasertext > h3 > a > span.manualteasertitle';
+Connector.trackSelector = 'div.teasertext > h3 > h3 > span.manualteasertitle';
+
+Connector.isPlaying = function () {
+	var result = false;
+	var state = retrieveJwplayerState();
+	if (typeof state === 'string') {
+		result = (state.toUpperCase() === 'PLAYING');
+	}
+	return result;
+};
+
+function retrieveJwplayerState() {
+	var scriptContent = "if (typeof jwplayer !== 'undefined') $('body').attr('tmp_state', jwplayer().getState !== 'undefined' ? jwplayer().getState() : '');\n"
+
+	var script = document.createElement('script');
+	script.id = 'tmpScript';
+	script.appendChild(document.createTextNode(scriptContent));
+	(document.body || document.head || document.documentElement).appendChild(script);
+
+	var ret = $("body").attr("tmp_state");
+
+	$("body").removeAttr("tmp_state");
+	$("#tmpScript").remove();
+
+	return ret;
+}

--- a/connectors/radioeins.js
+++ b/connectors/radioeins.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/* global Connector */
+
+Connector.playerSelector = '.livestream';
+Connector.artistSelector = 'p.artist';
+Connector.trackSelector = 'p.songtitle';
+
+Connector.isPlaying = function () {
+	var result = false;
+	var state = retrieveJwplayerState();
+	if (typeof state === 'string') {
+		result = (state.toUpperCase() === 'PLAYING');
+	}
+	return result;
+};
+
+function retrieveJwplayerState() {
+	var scriptContent = "if (typeof jwplayer !== 'undefined') $('body').attr('tmp_state', jwplayer().getState());\n"
+
+	var script = document.createElement('script');
+	script.id = 'tmpScript';
+	script.appendChild(document.createTextNode(scriptContent));
+	(document.body || document.head || document.documentElement).appendChild(script);
+
+	var ret = $("body").attr("tmp_state");
+
+	$("body").removeAttr("tmp_state");
+	$("#tmpScript").remove();
+
+	return ret;
+}

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -1088,5 +1088,17 @@ define(function () {
 		label: 'Deutschlandfunk Nova',
 		matches: ['*://www.deutschlandfunknova.de/*'],
 		js: ['connectors/deutschlandfunknova.js'],
+	},
+
+	{
+		label: 'radioeins',
+		matches: ['*://www.radioeins.de/livestream/*'],
+		js: ['connectors/radioeins.js'],
+	},
+
+	{
+		label: 'fritz',
+		matches: ['*://www.fritz.de/livestream/*'],
+		js: ['connectors/fritz.js'],
 	}];
 });

--- a/tests/connectors/fritz.js
+++ b/tests/connectors/fritz.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'https://www.fritz.de/livestream/index.html'
+	});
+};

--- a/tests/connectors/radioeins.js
+++ b/tests/connectors/radioeins.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'https://www.fluxfm.de/stream/#fluxfm/play'
+	});
+};


### PR DESCRIPTION
The player used by "radioeins" and "Fritz" is flash based, therefore it
is a bit complicated to get its state from inside our content script.
The function retrieveJwplayerState() injects code which gets the player
state and stores it in a document attribute (body.tmp_state), which then
can be read by our content script.